### PR TITLE
Automated refactoring audit script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ cron_state.db*
 
 # Supervisor restart sentinel
 .gaas-restart
+
+# Refactoring audit output
+to_review/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "import-linter>=2.0",
     "bandit>=1.7",
     "ruff>=0.4",
+    "claude-agent-sdk>=0.1.45",
 ]
 
 [tool.uv.sources]

--- a/scripts/refactor_audit.py
+++ b/scripts/refactor_audit.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Standalone refactoring audit script.
+
+Runs code quality tools, then passes their output plus a refactor prompt
+to a Claude agent that explores the codebase and writes refactoring
+opportunity files to to_review/.
+
+Operates in a temporary git worktree checked out from origin/main so it
+can run independently of whatever branch you're working on.
+
+Requirements:
+    claude-agent-sdk
+
+Usage:
+    uv run python scripts/refactor_audit.py
+"""
+
+import asyncio
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+QUALITY_TOOLS = [
+    {
+        "name": "mypy",
+        "cmd": ["uv", "run", "mypy", "app/", "packages/", "--ignore-missing-imports"],
+    },
+    {
+        "name": "complexipy",
+        "cmd": ["uv", "run", "complexipy", "app/", "packages/", "--max-complexity", "15"],
+    },
+    {
+        "name": "radon",
+        "cmd": ["uv", "run", "radon", "cc", "app/", "-a", "-nc"],
+    },
+    {
+        "name": "vulture",
+        "cmd": ["uv", "run", "vulture", "app/", "packages/", "--min-confidence", "80"],
+    },
+    {
+        "name": "ruff",
+        "cmd": ["uv", "run", "ruff", "check", "app/", "packages/", "tests/"],
+    },
+    {
+        "name": "bandit",
+        "cmd": ["uv", "run", "bandit", "-r", "app/", "-q"],
+    },
+]
+
+
+def create_worktree() -> Path:
+    """Create a temporary git worktree from origin/main."""
+    subprocess.run(
+        ["git", "fetch", "origin", "main"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    worktree_dir = Path(tempfile.mkdtemp(prefix="gaas-audit-"))
+    subprocess.run(
+        ["git", "worktree", "add", "--detach", str(worktree_dir), "origin/main"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    print(f"Created worktree at {worktree_dir}")
+    return worktree_dir
+
+
+def remove_worktree(worktree_dir: Path) -> None:
+    """Remove the temporary worktree and its directory."""
+    subprocess.run(
+        ["git", "worktree", "remove", "--force", str(worktree_dir)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+    )
+    if worktree_dir.exists():
+        shutil.rmtree(worktree_dir)
+
+
+def run_quality_tools(worktree_dir: Path) -> str:
+    """Run each quality tool via subprocess, collect stdout+stderr."""
+    sections = []
+    for tool in QUALITY_TOOLS:
+        name = tool["name"]
+        print(f"Running {name}...")
+        result = subprocess.run(
+            tool["cmd"],
+            cwd=worktree_dir,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        output = (result.stdout + result.stderr).strip()
+        sections.append(f"## {name}\n\n```\n{output}\n```")
+    return "\n\n".join(sections)
+
+
+def build_prompt(worktree_dir: Path, tool_output: str) -> str:
+    """Combine the refactor prompt template with tool output."""
+    env = Environment(
+        loader=FileSystemLoader([worktree_dir / "scripts", worktree_dir]),
+        keep_trailing_newline=True,
+    )
+    template = env.get_template("refactor_audit_prompt.md.j2")
+    return template.render(tool_output=tool_output)
+
+
+async def run_agent(prompt: str, worktree_dir: Path) -> None:
+    """Run a Claude agent with the given prompt."""
+    try:
+        from claude_agent_sdk import (  # noqa: E501
+            AssistantMessage,
+            ClaudeAgentOptions,
+            TextBlock,
+            ToolUseBlock,
+            query,
+        )
+    except ImportError:
+        print(
+            "claude-agent-sdk is not installed.\n"
+            "Install it with: pip install claude-agent-sdk",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    options = ClaudeAgentOptions(
+        allowed_tools=["Read", "Glob", "Grep", "Write"],
+        permission_mode="bypassPermissions",
+        cwd=str(worktree_dir),
+        max_turns=30,
+        setting_sources=["project"],
+    )
+
+    print("\nStarting Claude agent...\n")
+    async for message in query(prompt=prompt, options=options):
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    print(block.text)
+                elif isinstance(block, ToolUseBlock):
+                    print(f"  [{block.name}] {_summarize_tool_input(block.input)}")
+
+
+def _summarize_tool_input(input_data: dict) -> str:
+    """One-line summary of a tool call's input."""
+    if "file_path" in input_data:
+        return input_data["file_path"]
+    if "pattern" in input_data:
+        return input_data["pattern"]
+    if "command" in input_data:
+        cmd = input_data["command"]
+        return cmd[:80] + "..." if len(cmd) > 80 else cmd
+    return str(input_data)[:80]
+
+
+def copy_results(worktree_dir: Path) -> None:
+    """Copy to_review/ from the worktree back to the real repo."""
+    src = worktree_dir / "to_review"
+    if not src.exists():
+        print("\nWarning: agent did not create to_review/ in the worktree.", file=sys.stderr)
+        return
+    dest = REPO_ROOT / "to_review"
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(src, dest)
+    files = sorted(dest.glob("*.md"))
+    print(f"\nDone. {len(files)} file(s) copied to to_review/:")
+    for f in files:
+        print(f"  {f.name}")
+
+
+def main() -> None:
+    worktree_dir = create_worktree()
+    try:
+        (worktree_dir / "to_review").mkdir(exist_ok=True)
+        tool_output = run_quality_tools(worktree_dir)
+        prompt = build_prompt(worktree_dir, tool_output)
+        asyncio.run(run_agent(prompt, worktree_dir))
+        copy_results(worktree_dir)
+    finally:
+        remove_worktree(worktree_dir)
+        print("Worktree cleaned up.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/refactor_audit_prompt.md.j2
+++ b/scripts/refactor_audit_prompt.md.j2
@@ -1,0 +1,107 @@
+# Refactoring Audit
+
+You are a senior software architect performing a periodic refactoring audit of this codebase. Your goal is to identify tech debt, anti-patterns, missing test coverage, non-elegant solutions, non-extensible patterns, maintainability risks, and sources of possible future bugs.
+
+## Instructions
+
+### 1. Read the documentation first
+
+- Read `CLAUDE.md` (or equivalent project instructions) to understand the project's principles, architecture, and constraints.
+- Read `DECISIONS.md` in full. This document explains _why_ architectural choices were made. Do not propose undoing a decision unless the constraints that led to it have materially changed. If you believe constraints have changed, say so explicitly and recommend updating `DECISIONS.md` as part of the refactor.
+- Read any `AGENTS.md` files for subsystem-specific context.
+- Read `README.md` and any docs under `docs/` for additional architectural context.
+
+### 2. Explore the codebase
+
+Thoroughly read the source code — not just file names and structures, but actual implementations. Pay attention to:
+
+- **Inconsistent patterns**: Two modules solving the same problem differently. A convention followed in 4 places but broken in a 5th.
+- **Implicit coupling**: Modules that depend on each other's internal details rather than contracts. Import chains that create fragile ordering requirements. Module-level side effects that constrain when things can be imported.
+- **Error handling gaps**: Exceptions swallowed silently. Error paths that leave state inconsistent. Missing cleanup in failure scenarios. Try/except blocks that catch too broadly.
+- **Type safety erosion**: `Any` types, unchecked dict access, string-typed fields that should be enums, isinstance checks that suggest a missing abstraction.
+- **Test coverage gaps**: Code paths with no tests, especially in safety-critical or irreversible-action paths. Tests that assert on implementation details rather than behavior. Missing edge case coverage for boundary conditions. Test fixtures that mask real configuration issues.
+- **Abstraction problems**: Premature abstractions that add complexity without value. Missing abstractions where copy-paste duplication signals a pattern. Leaky abstractions where callers need to know internals.
+- **Concurrency and state**: Race conditions in shared mutable state. Assumptions about execution order that aren't enforced. File-system operations that aren't atomic when they should be.
+- **Configuration complexity**: Config schemas that are hard to validate or extend. Validation that happens too late (runtime instead of load time). Config patterns that are easy to misconfigure silently.
+- **Dependency issues**: Circular imports (even if currently avoided by careful ordering). Heavy imports in hot paths. Version-sensitive dependencies without pins.
+- **Extensibility bottlenecks**: Places where adding a new integration, action type, or feature requires touching many files. Hardcoded values that should be configurable. Closed designs where open ones would be natural.
+- **API surface bloat**: Re-export shims that have outlived their usefulness. Public functions that are only used internally. Multiple ways to do the same thing.
+- **Naming and readability**: Misleading names. Functions that do more than their name suggests. Magic numbers or strings without explanation.
+
+### 3. Evaluate what you find
+
+Not everything you notice is worth fixing. Apply these filters:
+
+- **Is it actually causing problems?** A slightly inelegant pattern that works correctly and is well-tested may not be worth the risk of refactoring. "Ugly but correct and tested" often beats "elegant but untested."
+- **Does it violate the project's own principles?** A pattern that contradicts the stated design principles (in CLAUDE.md or DECISIONS.md) is higher priority than a generic code smell.
+- **What's the blast radius?** A refactor that touches 2 files is lower risk than one that touches 20. Factor this into your recommendation.
+- **Have the constraints changed?** Some decisions were made under constraints (e.g., "we only have one integration" or "performance doesn't matter at this scale") that may no longer hold. If constraints have shifted, note this explicitly.
+
+### 4. Check DECISIONS.md for staleness
+
+Review each decision in `DECISIONS.md` and flag any that meet these criteria:
+
+- The constraints or tradeoffs cited in the rationale no longer apply.
+- The codebase has evolved to make the decision moot or contradictory.
+- New information (library updates, ecosystem changes, scale changes) invalidates the reasoning.
+- The decision was made speculatively ("we'll revisit when X") and X has happened.
+
+If any decisions are stale, include a recommendation to update `DECISIONS.md` as a standalone refactoring item.
+
+## Output Format
+
+If there are no meaningful refactoring opportunities, respond with:
+
+> Nothing of consequence requires refactoring.
+
+Otherwise, return a numbered list of refactoring opportunities, ordered by impact (highest first). Each item must include:
+
+### [N]. [Title — a concise name for the refactor]
+
+**Summary**: 2-3 sentences describing what would change and why.
+
+**Pros**:
+- [concrete benefit]
+
+**Cons**:
+- [concrete cost or risk]
+
+**Extensibility**: [How does this change affect the ease of adding new features, integrations, or capabilities? "No change" is a valid answer.]
+
+**Maintainability**: [How does this change affect the ease of understanding, modifying, and debugging the code? "No change" is a valid answer.]
+
+**Complexity to implement**: [Low / Medium / High — with a brief explanation of what's involved.]
+
+**Risk of introducing bugs**: [Low / Medium / High — with a note on what could go wrong and how to mitigate it.]
+
+**DECISIONS.md update needed**: [Yes/No — if Yes, briefly describe what should be added or changed.]
+
+---
+
+## Guidelines
+
+- Limit your output to **at most 3** refactoring opportunities. If you find more, keep only the highest-impact ones. Quality over quantity.
+- Do not recommend refactors that are purely cosmetic (renaming for style, reordering imports, adding docstrings to stable code).
+- Do not recommend adding features disguised as refactors. A refactor changes structure, not behavior.
+- Do not recommend refactors that would require changing the project's core principles. If a principle seems wrong, flag it as a DECISIONS.md review item instead.
+- Be specific. "Improve error handling" is not actionable. "Add cleanup logic to `worker.py:handle()` so that a failed `route_results()` call doesn't leave the task in `active/` indefinitely" is.
+- Consider the project's testing philosophy. If the project uses property-based testing for safety invariants, a refactor that makes those tests harder to write is a significant con.
+
+---
+
+# Code Quality Tool Output
+
+The following output was collected from static analysis tools. Use it as additional signal, but also explore the codebase yourself.
+
+{{ tool_output }}
+
+---
+
+# Output Instructions
+
+Write exactly 3 refactoring opportunity files:
+- `to_review/01-<slug>.md`
+- `to_review/02-<slug>.md`
+- `to_review/03-<slug>.md`
+
+Each file should contain one refactoring opportunity using the output format from the prompt above. The slug should be a short, kebab-case summary of the refactor.

--- a/uv.lock
+++ b/uv.lock
@@ -365,6 +365,22 @@ wheels = [
 ]
 
 [[package]]
+name = "claude-agent-sdk"
+version = "0.1.45"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "mcp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/e2/c5d5c4743ece496492a930bb75b878c830a9a9878ae3327b2d292647a8fa/claude_agent_sdk-0.1.45.tar.gz", hash = "sha256:97c1e981431b5af1e08c34731906ab8d4a58fe0774a04df0ea9587dcabc85151", size = 62436, upload-time = "2026-03-03T17:21:08.595Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/29/a28b6dfac54dfceddaa47e16c2b9cb61cc2ace4b4a1de064ab6d76debcbd/claude_agent_sdk-0.1.45-py3-none-macosx_11_0_arm64.whl", hash = "sha256:26a5cc60c3a394f5b814f6b2f67650819cbcd38c405bbdc11582b3e097b3a770", size = 57761380, upload-time = "2026-03-03T17:20:55.066Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/7c/a803cc6e40de8b13cc822c66fd96c96d88f994983c2622d80cb8b708bb30/claude_agent_sdk-0.1.45-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:decc741b53e0b2c10a64fd84c15acca1102077d9f99941c54905172cd95160c9", size = 73402101, upload-time = "2026-03-03T17:20:58.604Z" },
+    { url = "https://files.pythonhosted.org/packages/32/51/bdb9832728189673c60c605854c2153e17dce384a64a6dc88cdbb254ce86/claude_agent_sdk-0.1.45-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:7d48dcf4178c704e4ccbf3f1f4ebf20b3de3f03d0592086c1f3abd16b8ca441e", size = 74091498, upload-time = "2026-03-03T17:21:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/13/37/02e60d7f93aedc8f63f9404cbf2a48bf5d47c27ccb9c0a0f03c803882fa5/claude_agent_sdk-0.1.45-py3-none-win_amd64.whl", hash = "sha256:d1cf34995109c513d8daabcae7208edc260b553b53462a9ac06a7c40e240a288", size = 75784070, upload-time = "2026-03-03T17:21:05.573Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -990,6 +1006,7 @@ gemini = [
 [package.dev-dependencies]
 dev = [
     { name = "bandit" },
+    { name = "claude-agent-sdk" },
     { name = "complexipy" },
     { name = "deptry" },
     { name = "hypothesis" },
@@ -1021,6 +1038,7 @@ provides-extras = ["gemini"]
 [package.metadata.requires-dev]
 dev = [
     { name = "bandit", specifier = ">=1.7" },
+    { name = "claude-agent-sdk", specifier = ">=0.1.45" },
     { name = "complexipy", specifier = ">=5.2.0" },
     { name = "deptry", specifier = ">=0.16" },
     { name = "hypothesis", specifier = ">=6.100" },
@@ -1304,6 +1322,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "hypothesis"
 version = "6.151.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1581,6 +1608,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
 ]
 
 [[package]]
@@ -2067,6 +2119,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2145,6 +2211,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -2600,6 +2685,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/9f/c3695c2d2d4ef70072c3a06992850498b01c6bc9be531950813716b426fa/sse_starlette-3.3.2.tar.gz", hash = "sha256:678fca55a1945c734d8472a6cad186a55ab02840b4f6786f5ee8770970579dcd", size = 32326, upload-time = "2026-02-28T11:24:34.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/28/8cb142d3fe80c4a2d8af54ca0b003f47ce0ba920974e7990fa6e016402d1/sse_starlette-3.3.2-py3-none-any.whl", hash = "sha256:5c3ea3dad425c601236726af2f27689b74494643f57017cafcb6f8c9acfbb862", size = 14270, upload-time = "2026-02-28T11:24:32.984Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a script that runs the code quality tools from CLAUDE.md, feeds the output to a Claude agent via `claude-agent-sdk`, and lets the agent explore the codebase to produce three prioritized refactoring opportunity files in `to_review/`.

### Why this exists

We already had the refactor prompt (`scratch.refactor_prompt.md`) and the code quality tool list in CLAUDE.md. Running a refactoring audit meant manually copying tool output into a Claude conversation and babysitting the process. This automates the whole thing into a single `uv run python scripts/refactor_audit.py` invocation.

### Why a git worktree

The script fetches `origin/main` and spins up a temporary detached worktree for the entire run. Quality tools and the agent both operate against that worktree, not your working tree.

This was the main design question. Three options came up:

1. **Run against the working directory.** Simplest, but if you're mid-feature on a branch, the audit would flag your in-progress work as issues. The whole point is to audit the state of `main`.

2. **Clone the repo into a temp directory.** Works, but cloning is slow and wastes disk. Git already has worktrees for exactly this use case.

3. **Git worktree from `origin/main`.** Fast (shares the object store with your existing clone), isolated, and cleaned up automatically in a `finally` block. Results get copied back to `to_review/` in the real repo when the agent finishes.

Option 3 won. The fetch + worktree add takes under a second on a local repo.

### Why Jinja for the prompt

The prompt template includes the full refactor prompt from `scratch.refactor_prompt.md` via `{% include %}` and injects the tool output with `{{ tool_output }}`. Jinja2 is already a project dependency. An early version used an f-string, but that got hard to read fast. The template keeps the prompt as readable markdown in its own file.

### Dependency placement

`claude-agent-sdk` is a dev dependency in `pyproject.toml`. It's only used by this script, never by the GaaS runtime. The script itself lives in `scripts/`, outside `app/`, to make the boundary clear.