### PR TITLE
Add TypedDict definitions for task payloads and queue records

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -90,6 +90,17 @@ Why: the dangerous failure mode is a task existing in two directories (processed
 
 Priority 9 for unauthenticated emails ensures the user's important messages are processed first. The gap between priority levels leaves room for future insertions and we can also use multiple numbers like 8, 801, 81... etc if we want finer granularity.
 
+### TypedDicts for task payloads and queue records
+
+`TaskPayload` and `TaskRecord` in `gaas_sdk.task` define the canonical shape of task dicts. They're structural (TypedDict), not runtime-enforced. mypy and IDEs can catch key typos; handler signatures document what they receive.
+
+The base `TaskPayload` only covers fields shared across all task types: `type` (required) and `integration` (not required — `script.run` tasks omit it). Per-task-type fields (`uid`, `org`, `repo`, `inputs`, `on_result`, etc.) are accessed via `.get()` and intentionally not declared. Adding per-type subtypes is optional and can happen incrementally without breaking the base contract.
+
+This was chosen over two alternatives:
+
+- **Pydantic models** — Runtime validation would add overhead to every enqueue/dequeue cycle for no safety gain (the queue is internal, not a trust boundary). TypedDicts are zero-cost at runtime.
+- **Per-type dataclasses** — Would require deserialization at every handler boundary. The dict-in, dict-out pattern is simpler and already established.
+
 ---
 
 ## Provenance System

--- a/app/actions/script.py
+++ b/app/actions/script.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import app.human_log  # noqa: F401 — registers log.human()
 from app.config import config
+from gaas_sdk.task import TaskRecord
 
 log = logging.getLogger(__name__)
 
@@ -134,7 +135,7 @@ def execute(script_def, inputs: dict[str, str]) -> str | None:
                 f.unlink()
 
 
-def handle(task: dict) -> None:
+def handle(task: TaskRecord) -> None:
     """Worker handler for script.run tasks."""
     payload = task["payload"]
     script_name = payload.get("script_name", "")

--- a/app/queue.py
+++ b/app/queue.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import yaml
 
 from app.config import config
+from gaas_sdk.task import TaskRecord
 
 log = logging.getLogger(__name__)
 
@@ -137,7 +138,7 @@ def enqueue(payload: dict, priority: int = 5, provenance: str | None = None) -> 
     return task_id
 
 
-def dequeue() -> dict | None:
+def dequeue() -> TaskRecord | None:
     pending_dir = BASE_DIR / "pending"
     files = sorted(f.name for f in pending_dir.iterdir() if f.suffix == ".yaml")
 
@@ -169,7 +170,7 @@ def complete(task_id: str, result: dict | None = None):
     src = BASE_DIR / "active" / filename
     dst = BASE_DIR / "done" / filename
 
-    task = yaml.safe_load(src.read_text())
+    task: TaskRecord = yaml.safe_load(src.read_text())
     task["status"] = "done"
     task["completed_at"] = _now().isoformat()
     if result is not None:
@@ -184,7 +185,7 @@ def fail(task_id: str, error: str):
     src = BASE_DIR / "active" / filename
     dst = BASE_DIR / "failed" / filename
 
-    task = yaml.safe_load(src.read_text())
+    task: TaskRecord = yaml.safe_load(src.read_text())
     task["status"] = "failed"
     task["failed_at"] = _now().isoformat()
     task["error"] = error

--- a/app/result_routes.py
+++ b/app/result_routes.py
@@ -18,11 +18,12 @@ from pathlib import Path
 import app.human_log  # noqa: F401 — registers log.human()
 from gaas_sdk import runtime
 from gaas_sdk.store import NoteStore
+from gaas_sdk.task import TaskRecord
 
 log = logging.getLogger(__name__)
 
 
-def route_results(result: dict, task: dict) -> None:
+def route_results(result: dict, task: TaskRecord) -> None:
     """Dispatch a handler's return value to configured result routes.
 
     Reads ``on_result`` from the task payload. Falls back to a ``note``
@@ -51,7 +52,7 @@ def route_results(result: dict, task: dict) -> None:
             )
 
 
-def _route_note(result: dict, task: dict, route_config: dict) -> Path:
+def _route_note(result: dict, task: TaskRecord, route_config: dict) -> Path:
     """Save result as a markdown note with frontmatter.
 
     Directory is derived from the task type unless overridden by

--- a/app/worker.py
+++ b/app/worker.py
@@ -9,6 +9,7 @@ from app.result_routes import route_results
 from app.runtime_init import register_runtime
 from app.loader import load_all_modules
 from app.integrations import HANDLERS, register_all
+from gaas_sdk.task import TaskRecord
 
 log = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ def _shutdown_handler(signum, frame):
     log.info("Received signal %s, shutting down gracefully…", signum)
 
 
-def handle(task: dict):
+def handle(task: TaskRecord):
     task_type = task["payload"].get("type")
     handler = HANDLERS.get(task_type)
     if handler is None:

--- a/packages/gaas-email/src/gaas_email/platforms/inbox/act.py
+++ b/packages/gaas-email/src/gaas_email/platforms/inbox/act.py
@@ -1,6 +1,7 @@
 import logging
 
 from gaas_sdk import runtime
+from gaas_sdk.task import TaskRecord
 from .const import SIMPLE_ACTIONS
 from .store import EmailStore
 
@@ -25,7 +26,7 @@ def _execute_action(email, action) -> None:
             log.warning("email.inbox.act: unknown action dict %r, skipping", action)
 
 
-def handle(task: dict):
+def handle(task: TaskRecord):
     from ...mail import Mailbox
 
     integration_id = task["payload"]["integration"]

--- a/packages/gaas-email/src/gaas_email/platforms/inbox/check.py
+++ b/packages/gaas-email/src/gaas_email/platforms/inbox/check.py
@@ -3,6 +3,7 @@ import re
 from datetime import date, timedelta
 
 from gaas_sdk import runtime
+from gaas_sdk.task import TaskRecord
 from .store import EmailStore
 
 log = logging.getLogger(__name__)
@@ -19,7 +20,7 @@ def _parse_window_days(window: str) -> int:
     return int(match.group(1))
 
 
-def handle(task: dict):
+def handle(task: TaskRecord):
     from ...mail import Mailbox
 
     integration_id = task["payload"]["integration"]

--- a/packages/gaas-email/src/gaas_email/platforms/inbox/classify.py
+++ b/packages/gaas-email/src/gaas_email/platforms/inbox/classify.py
@@ -8,6 +8,7 @@ import frontmatter
 from gaas_sdk import runtime
 from gaas_sdk.classify import build_schema, make_jinja_env
 from gaas_sdk.models import ClassificationConfig
+from gaas_sdk.task import TaskRecord
 from .const import DEFAULT_CLASSIFICATIONS
 from .store import EmailStore
 
@@ -32,7 +33,7 @@ def _render_prompt(email, classifications: dict[str, ClassificationConfig]) -> s
     )
 
 
-def handle(task: dict):
+def handle(task: TaskRecord):
     from ...mail import Mailbox
 
     integration_id = task["payload"]["integration"]

--- a/packages/gaas-email/src/gaas_email/platforms/inbox/collect.py
+++ b/packages/gaas-email/src/gaas_email/platforms/inbox/collect.py
@@ -1,12 +1,13 @@
 import logging
 
 from gaas_sdk import runtime
+from gaas_sdk.task import TaskRecord
 from .store import EmailStore
 
 log = logging.getLogger(__name__)
 
 
-def handle(task: dict):
+def handle(task: TaskRecord):
     from ...mail import Mailbox
 
     integration_id = task["payload"]["integration"]

--- a/packages/gaas-email/src/gaas_email/platforms/inbox/evaluate.py
+++ b/packages/gaas-email/src/gaas_email/platforms/inbox/evaluate.py
@@ -12,6 +12,7 @@ from gaas_sdk.evaluate import (
     resolve_action_provenance,
     unwrap_actions,
 )
+from gaas_sdk.task import TaskRecord
 from .const import DEFAULT_CLASSIFICATIONS, DETERMINISTIC_SOURCES
 from .store import EmailStore
 
@@ -83,7 +84,7 @@ def _make_resolver(snapshot: EmailSnapshot):
     return resolve_value
 
 
-def handle(task: dict):
+def handle(task: TaskRecord):
     integration_id = task["payload"]["integration"]
     integration = runtime.get_integration(integration_id)
     platform = runtime.get_platform(integration_id, "inbox")

--- a/packages/gaas-gemini/src/gaas_gemini/services/web_research.py
+++ b/packages/gaas-gemini/src/gaas_gemini/services/web_research.py
@@ -12,13 +12,14 @@ from __future__ import annotations
 import logging
 
 from gaas_sdk import runtime
+from gaas_sdk.task import TaskRecord
 
 from gaas_gemini.client import GeminiClient
 
 log = logging.getLogger(__name__)
 
 
-def handle(task: dict) -> dict:
+def handle(task: TaskRecord) -> dict:
     """Handle a service.gemini.web_research queue task.
 
     Receives the full task dict from the worker, consistent with

--- a/packages/gaas-github/src/gaas_github/platforms/issues/act.py
+++ b/packages/gaas-github/src/gaas_github/platforms/issues/act.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 
 import logging
 
+from gaas_sdk.task import TaskRecord
+
 log = logging.getLogger(__name__)
 
 
-def handle(task: dict):
+def handle(task: TaskRecord):
     org = task["payload"]["org"]
     repo = task["payload"]["repo"]
     number = task["payload"]["number"]

--- a/packages/gaas-github/src/gaas_github/platforms/issues/check.py
+++ b/packages/gaas-github/src/gaas_github/platforms/issues/check.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import logging
 
 from gaas_sdk import runtime
+from gaas_sdk.task import TaskRecord
 
 from .store import IssueStore
 
 log = logging.getLogger(__name__)
 
 
-def handle(task: dict):
+def handle(task: TaskRecord):
     from ...client import GitHubClient
 
     integration_id = task["payload"]["integration"]

--- a/packages/gaas-github/src/gaas_github/platforms/issues/classify.py
+++ b/packages/gaas-github/src/gaas_github/platforms/issues/classify.py
@@ -10,6 +10,7 @@ import frontmatter
 from gaas_sdk import runtime
 from gaas_sdk.classify import build_schema, make_jinja_env
 from gaas_sdk.models import ClassificationConfig
+from gaas_sdk.task import TaskRecord
 
 from .const import DEFAULT_CLASSIFICATIONS
 from .store import IssueStore
@@ -41,7 +42,7 @@ def _render_prompt(
     )
 
 
-def handle(task: dict):
+def handle(task: TaskRecord):
     from ...client import GitHubClient
 
     integration_id = task["payload"]["integration"]

--- a/packages/gaas-github/src/gaas_github/platforms/issues/collect.py
+++ b/packages/gaas-github/src/gaas_github/platforms/issues/collect.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import logging
 
 from gaas_sdk import runtime
+from gaas_sdk.task import TaskRecord
 
 from .store import IssueStore
 
 log = logging.getLogger(__name__)
 
 
-def handle(task: dict):
+def handle(task: TaskRecord):
     from ...client import GitHubClient
 
     integration_id = task["payload"]["integration"]

--- a/packages/gaas-github/src/gaas_github/platforms/issues/evaluate.py
+++ b/packages/gaas-github/src/gaas_github/platforms/issues/evaluate.py
@@ -13,6 +13,7 @@ from gaas_sdk.evaluate import (
     resolve_action_provenance,
     unwrap_actions,
 )
+from gaas_sdk.task import TaskRecord
 from .const import DEFAULT_CLASSIFICATIONS, DETERMINISTIC_SOURCES
 from .store import IssueStore
 
@@ -60,7 +61,7 @@ def _make_resolver(snapshot: IssueSnapshot):
     return resolve_value
 
 
-def handle(task: dict):
+def handle(task: TaskRecord):
     integration_id = task["payload"]["integration"]
     integration = runtime.get_integration(integration_id)
     platform = runtime.get_platform(integration_id, "issues")

--- a/packages/gaas-github/src/gaas_github/platforms/pull_requests/act.py
+++ b/packages/gaas-github/src/gaas_github/platforms/pull_requests/act.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 
 import logging
 
+from gaas_sdk.task import TaskRecord
+
 log = logging.getLogger(__name__)
 
 
-def handle(task: dict):
+def handle(task: TaskRecord):
     org = task["payload"]["org"]
     repo = task["payload"]["repo"]
     number = task["payload"]["number"]

--- a/packages/gaas-github/src/gaas_github/platforms/pull_requests/check.py
+++ b/packages/gaas-github/src/gaas_github/platforms/pull_requests/check.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import logging
 
 from gaas_sdk import runtime
+from gaas_sdk.task import TaskRecord
 
 from .store import PullRequestStore
 
 log = logging.getLogger(__name__)
 
 
-def handle(task: dict):
+def handle(task: TaskRecord):
     from ...client import GitHubClient
 
     integration_id = task["payload"]["integration"]

--- a/packages/gaas-github/src/gaas_github/platforms/pull_requests/classify.py
+++ b/packages/gaas-github/src/gaas_github/platforms/pull_requests/classify.py
@@ -10,6 +10,7 @@ import frontmatter
 from gaas_sdk import runtime
 from gaas_sdk.classify import build_schema, make_jinja_env
 from gaas_sdk.models import ClassificationConfig
+from gaas_sdk.task import TaskRecord
 
 from .const import DEFAULT_CLASSIFICATIONS
 from .store import PullRequestStore
@@ -43,7 +44,7 @@ def _render_prompt(
     )
 
 
-def handle(task: dict):
+def handle(task: TaskRecord):
     from ...client import GitHubClient
 
     integration_id = task["payload"]["integration"]

--- a/packages/gaas-github/src/gaas_github/platforms/pull_requests/collect.py
+++ b/packages/gaas-github/src/gaas_github/platforms/pull_requests/collect.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import logging
 
 from gaas_sdk import runtime
+from gaas_sdk.task import TaskRecord
 
 from .store import PullRequestStore
 
 log = logging.getLogger(__name__)
 
 
-def handle(task: dict):
+def handle(task: TaskRecord):
     from ...client import GitHubClient
 
     integration_id = task["payload"]["integration"]

--- a/packages/gaas-github/src/gaas_github/platforms/pull_requests/evaluate.py
+++ b/packages/gaas-github/src/gaas_github/platforms/pull_requests/evaluate.py
@@ -13,6 +13,7 @@ from gaas_sdk.evaluate import (
     resolve_action_provenance,
     unwrap_actions,
 )
+from gaas_sdk.task import TaskRecord
 from .const import DEFAULT_CLASSIFICATIONS, DETERMINISTIC_SOURCES
 from .store import PullRequestStore
 
@@ -64,7 +65,7 @@ def _make_resolver(snapshot: PRSnapshot):
     return resolve_value
 
 
-def handle(task: dict):
+def handle(task: TaskRecord):
     integration_id = task["payload"]["integration"]
     integration = runtime.get_integration(integration_id)
     platform = runtime.get_platform(integration_id, "pull_requests")

--- a/packages/gaas-sdk/src/gaas_sdk/__init__.py
+++ b/packages/gaas-sdk/src/gaas_sdk/__init__.py
@@ -34,4 +34,5 @@ from gaas_sdk.actions import (  # noqa: F401
     is_service_action,
     resolve_inputs,
 )
+from gaas_sdk.task import TaskPayload, TaskRecord  # noqa: F401
 from gaas_sdk import runtime  # noqa: F401

--- a/packages/gaas-sdk/src/gaas_sdk/task.py
+++ b/packages/gaas-sdk/src/gaas_sdk/task.py
@@ -1,0 +1,46 @@
+"""TypedDict definitions for task payloads and queue records.
+
+These define the canonical shape of task dicts that flow through the queue,
+worker, result routes, and every integration handler. Structural typing only —
+no runtime enforcement. Per-task-type fields (uid, org, repo, inputs, etc.)
+are accessed via .get() and not enforced here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, NotRequired, TypedDict
+
+
+class TaskPayload(TypedDict):
+    """Shared fields present in every task payload.
+
+    Per-task-type keys (uid, org, repo, inputs, on_result, etc.)
+    are not declared here — handlers access them via .get().
+    """
+
+    type: str
+    integration: NotRequired[str]
+
+
+class TaskRecord(TypedDict):
+    """A task as it exists on disk in the queue.
+
+    Created by queue.enqueue(), read by queue.dequeue(), and passed
+    through the worker to handler functions.
+
+    The payload field is typed as dict[str, Any] rather than TaskPayload
+    because handlers access per-task-type keys (uid, org, inputs, etc.)
+    via .get(). TaskPayload documents the shared fields; this keeps
+    dynamic access patterns working without mypy complaints.
+    """
+
+    id: str
+    created_at: str
+    status: str
+    priority: int
+    payload: dict[str, Any]
+    provenance: NotRequired[str]
+    completed_at: NotRequired[str]
+    result: NotRequired[dict]
+    failed_at: NotRequired[str]
+    error: NotRequired[str]

--- a/packages/gaas-sdk/tests/test_task.py
+++ b/packages/gaas-sdk/tests/test_task.py
@@ -1,0 +1,36 @@
+"""Smoke tests for TaskPayload and TaskRecord TypedDicts."""
+
+from gaas_sdk.task import TaskPayload, TaskRecord
+
+
+def test_imports():
+    """TaskPayload and TaskRecord are importable from gaas_sdk.task."""
+    assert TaskPayload is not None
+    assert TaskRecord is not None
+
+
+def test_top_level_reexport():
+    """TaskPayload and TaskRecord are re-exported from gaas_sdk."""
+    from gaas_sdk import TaskPayload as TP, TaskRecord as TR
+
+    assert TP is TaskPayload
+    assert TR is TaskRecord
+
+
+def test_conforming_dict():
+    """A dict matching the TaskRecord shape is accepted as valid."""
+    record: TaskRecord = {
+        "id": "5_20260304T120000Z_abcd1234--deadbeef--email.inbox.check",
+        "created_at": "2026-03-04T12:00:00+00:00",
+        "status": "pending",
+        "priority": 5,
+        "payload": {"type": "email.inbox.check", "integration": "email.personal"},
+    }
+    assert record["id"].startswith("5_")
+    assert record["payload"]["type"] == "email.inbox.check"
+
+
+def test_payload_without_integration():
+    """TaskPayload works without the optional integration field."""
+    payload: TaskPayload = {"type": "script.run"}
+    assert payload["type"] == "script.run"


### PR DESCRIPTION
## Summary

The task dict (`{"id": ..., "status": ..., "payload": {...}}`) is the most-touched data structure in GaaS. It flows through the queue, worker, result router, and every single handler. Until now it had no schema. Every access was `task["payload"]["whatever"]` on a bare `dict` with zero IDE support and no way for mypy to catch a typo.

This adds `TaskPayload` and `TaskRecord` TypedDicts in `gaas_sdk.task` and threads them through the codebase. No runtime behavior changes.

## Why TypedDicts

We considered three approaches:

**Pydantic models** were the obvious first thought. But the queue is internal, not a trust boundary. We already validate at system boundaries (config loading, LLM output). Adding runtime validation to every enqueue/dequeue cycle would burn CPU for no safety gain. The queue is filesystem YAML that we write and read ourselves.

**Per-type dataclasses** (one for email tasks, one for GitHub tasks, etc.) would give us the strongest typing. But every handler would need a deserialization step at the top, and the dict-in/dict-out pattern is deeply established. Every test builds plain dicts. Every handler destructures with `.get()`. Migrating all of that would be a big change with real risk, for a codebase where the handlers are already working fine.

**TypedDicts** hit the sweet spot. Zero cost at runtime (they're just type hints), IDEs autocomplete the fields, mypy catches key typos, and handler signatures now document what they actually receive. The migration is mechanical: change `dict` to `TaskRecord` in signatures, add an import, done.

## The payload typing compromise

One subtlety worth calling out. `TaskRecord.payload` is typed as `dict[str, Any]` rather than `TaskPayload`. We tried using `TaskPayload` directly, but it only declares the two shared fields (`type` and `integration`). Every handler immediately does things like `task["payload"]["uid"]` or `task["payload"].get("inputs", {})`, and mypy gets upset about accessing keys that aren't declared on the TypedDict.

We could have declared per-task-type payload subtypes, but that's a much bigger commitment and doesn't match how the code actually works today. So `TaskPayload` exists as documentation of the shared contract, and `TaskRecord.payload` stays `dict[str, Any]` to keep the existing dynamic access patterns clean. Per-type subtypes can be added incrementally later if they prove useful.