### PR TITLE
Document queue policy and result routing decisions

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -111,6 +111,56 @@ With complete-then-route, the `done/` task file (which includes the full result 
 
 ---
 
+## Queue Policy System
+
+### Policy layer above raw enqueue
+
+`queue_policy.policy_enqueue()` wraps `queue.enqueue()` with config-driven dedup and rate limiting. The raw `enqueue()` still exists and is used directly by manual API triggers (`POST /integrations/.../run`). Scheduled tasks and `runtime.enqueue()` (automation-driven code) go through `policy_enqueue()`.
+
+Why two entry points: if a user manually triggers a run via the API, they want it to happen now regardless of whether a similar task is pending or the rate limit has been hit. Policies exist to prevent runaway automation, not to block intentional human actions.
+
+The risk of having two entry points is that a contributor might call `queue.enqueue()` directly in new automation code, bypassing policies. The naming convention makes the intent clear: `policy_enqueue` is the default for automated paths, raw `enqueue` is the exception for manual triggers.
+
+### Policy inheritance via `model_fields_set`
+
+Per-task-type overrides merge with defaults using Pydantic's `model_fields_set` to distinguish explicitly-set values from Pydantic-filled defaults. When a user writes `overrides: { "email.inbox.check": { rate_limit: { max: 5, per: "1h" } } }`, only `rate_limit` is in `model_fields_set`. The override inherits `deduplicate_pending` from defaults rather than clobbering it with the model's default value.
+
+Why: naive `dict.update()` or `model.model_dump()` merging treats Pydantic defaults as user intent. If the default for `deduplicate_pending` is `true` and the user only wants to set a rate limit, a naive merge would still "set" `deduplicate_pending=true` — which happens to be correct by coincidence. But if the global default were later changed to `false`, the override would silently keep the old behavior. `model_fields_set` makes the merge correct regardless of what defaults are.
+
+### Zero-YAML-parsing policy checks
+
+Both dedup and rate limiting operate on filenames only, never parsing YAML. Dedup globs for `*--{fingerprint}--{task_type}.yaml` in `pending/`. Rate limiting globs for `*--*--{task_type}.yaml` across all directories and filters by timestamp extracted from the filename.
+
+This is why the task ID format includes `--`-separated fingerprint and task type suffixes. The format was designed to support policy checks without the I/O cost of reading and parsing every task file. For a queue with dozens of pending tasks, this is the difference between a glob and dozens of YAML loads.
+
+---
+
+## Result Routing
+
+### Route results after completion, not before
+
+The worker completes a task before routing its results. See "Complete before route: task state is the source of truth" in the Task Queue Design section for the full rationale. This ordering means the `done/` task file (with the full result dict) is always the recovery point if routing fails.
+
+### `on_result` in task payload, not in config
+
+Result routing is configured per-task via an `on_result` field in the task payload, not per-integration in `config.yaml`. Service actions set `on_result` at enqueue time based on the manifest and automation config.
+
+Why: the same service might be called from different automations with different routing needs. One automation might want results saved as notes, another might want a webhook notification (future). Putting routing in the task payload rather than global config keeps this flexible without adding conditional logic to the router.
+
+### Default-to-note for service tasks
+
+Service tasks that lack explicit `on_result` config fall back to the `note` route. Non-service tasks (platform handlers like `email.inbox.classify`) with no `on_result` produce no routing — their results are platform-internal.
+
+Why: service handlers exist to produce output (research results, summaries, etc.). Silently discarding that output is always wrong. The `note` fallback ensures service output is persisted even if the user hasn't configured explicit routing. Platform handlers, by contrast, drive pipelines (check → collect → classify → evaluate → act) where the "result" is the next task in the chain, not user-facing output.
+
+### Extensibility via route type dispatch
+
+New route types (e.g., `chat_reply`, `webhook`) are added by implementing a handler function and adding a branch to the dispatcher in `route_results()`. Each route type is independent — a single task can have multiple routes, and a failure in one doesn't affect others.
+
+The current implementation only has `note`. The dispatch pattern was chosen over a registry or plugin system because the number of route types will remain small (likely under 5) and a simple `if/elif` is easier to audit than dynamic dispatch for a system where routing failures should be obvious, not hidden behind abstraction layers.
+
+---
+
 ## Provenance System
 
 ### Namespaces as provenance


### PR DESCRIPTION
Two architectural patterns landed without corresponding entries in DECISIONS.md. They're non-obvious enough that a new contributor could easily misuse them. This adds the rationale.

## Queue Policy System

The queue has two entry points now: `queue.enqueue()` (raw) and `policy_enqueue()` (with dedup + rate limiting). That split is intentional -- manual API triggers should bypass policies because the human said "run this now" -- but someone writing new automation code could easily grab the wrong one.

The policy inheritance model also needed writing down. Per-task-type overrides merge with defaults using Pydantic's `model_fields_set` to tell apart "the user wrote this" from "Pydantic filled in a default." Without that distinction you get a subtle bug: change a global default and overrides silently keep the old value because the naive merge already cemented it. This is the kind of thing that works perfectly until it doesn't, and the failure mode is silent.

Considered just adding code comments, but the `model_fields_set` trick really needs the "why" spelled out in a way that inline comments can't do well.

## Result Routing

Result routing dispatches service handler output to destinations configured per-task via `on_result` in the payload.

The main design choice was where routing config should live. Two options:

- **Global config** (per-integration) -- simpler to set up, but every invocation of a service gets routed the same way. No flexibility if two automations calling the same service want different outputs.
- **Per-task payload** (what we went with) -- the automation sets `on_result` at enqueue time. Same service, different automations, different destinations. Slightly more wiring but the flexibility pays off as soon as you have more than one automation triggering the same service.

The default-to-note fallback for service tasks exists because service handlers produce output for humans. Dropping it silently is always wrong. Platform handlers are different -- their output is just the next task in the pipeline.

For the route type dispatch itself, we considered a registry/plugin pattern but that's way too much machinery for what'll likely stay under five route types. A plain `if/elif` is easier to grep, easier to audit, and makes routing failures show up in the obvious place instead of somewhere behind a dynamic dispatch layer.

## Script Logging Bridge

Already documented under "Preamble-injected logging helpers" from when scripts were first added. The `\x1e` rationale was captured then. No new entry needed.