### PR TITLE
Document pipeline handler duplication as deliberate, with trigger to revisit

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -360,6 +360,16 @@ The line: if it operates on core config types and is identical across all platfo
 
 This was originally "everything stays in the integration" but was refined when three-way duplication of the evaluation engine across platforms created a maintenance burden. The evaluation engine is the safety-critical dispatch boundary -- having a single authoritative copy reduces the risk of divergence in safety-critical code. Integrations import from `gaas_sdk.evaluate` and `gaas_sdk.classify`.
 
+### Pipeline handler duplication is accepted — extract when a fourth integration lands
+
+The evaluate, classify, and check handlers across email/inbox, github/issues, and github/pull_requests are 80-93% structurally identical (snapshot construction, resolver closures, the evaluate-resolve-enqueue flow, the classify skip-check). This is known duplication, not accidental.
+
+Why not extract now: three platforms is not enough signal that the pattern is stable. The email resolver's nested dict lookups (`authentication.*`, `calendar.*`) don't fit neatly into a generic resolver, which suggests the abstraction boundary isn't obvious yet. Premature extraction creates coupling between the SDK and platform handler structure, making it harder to write a handler that breaks the mold. The cost of the current duplication is manageable — it's ~300 lines per platform of well-tested, straightforward code.
+
+When to revisit: when a fourth integration (e.g., Linear, Slack) is added. At that point there will be enough examples to see which parts of the orchestration flow are truly universal and which are platform-specific. The extraction should target the orchestration layer (load note, build snapshot, evaluate, resolve provenance, enqueue) while keeping snapshot definitions, resolver hooks, and prompt rendering in the integration. Start with evaluate handlers (highest duplication at 93%) as a pilot.
+
+Until then, when fixing a bug in the evaluation flow, grep for the same pattern across all three platforms and apply the fix to each. This is the cost of isolation.
+
 ### `const.py` loaded via `spec_from_file_location`, not `import_module`
 
 Platform const modules are loaded using `importlib.util.spec_from_file_location` for both builtin and custom modules. This bypasses the package `__init__.py`, avoiding circular imports when `const.py` is loaded during config validation (which happens at module import time, before the full integration packages are initialized).


### PR DESCRIPTION
## Summary

Document the decision to keep pipeline handler duplication across platforms for now, with a concrete trigger for when to revisit.

## Why

Got feedback that the evaluate, classify, and check handlers across our three platforms (email/inbox, github/issues, github/pull_requests) are 80-93% structurally identical and should be extracted into shared utilities. The feedback is correct on the numbers. But I think it's premature.

Three approaches were on the table:

**1. Extract now into shared SDK orchestration layer.** Build a generic pipeline base that handles the load-snapshot-evaluate-resolve-enqueue flow, with platform-specific hooks for snapshot fields, resolvers, and prompt rendering. This would cut ~1,200 lines of near-duplicate code down to maybe 50 lines of config per platform. The problem: the email resolver does nested dict lookups (`authentication.*`, `calendar.*`) that don't map cleanly to a generic resolver interface. That's a hint the abstraction boundary isn't settled yet. Extracting now means we'd likely reshape the abstraction when integration #4 arrives anyway, and in the meantime we've added coupling between the SDK and every platform's handler structure.

**2. Do nothing, don't even document it.** The duplication is working fine, tests pass, handlers are readable. But "known duplication" that isn't documented anywhere becomes "accidental duplication" to the next person reading the code. They'll try to DRY it up without knowing the tradeoffs were already considered.

**3. Document the decision and set a trigger.** Accept the duplication as a deliberate cost of integration isolation. Write down why, write down when to revisit (fourth integration), and write down the extraction strategy for when that day comes. This is what we went with.

The existing DECISIONS.md entry "Integration isolation over shared abstractions" already covers *what* goes in the SDK vs integrations. The new entry sits right below it and addresses the specific question of the pipeline orchestration layer that lives above those SDK primitives.