### PR TITLE
Surface git errors instead of swallowing them

### DIFF
--- a/gaas-bot/src/gaas_bot/core/git.py
+++ b/gaas-bot/src/gaas_bot/core/git.py
@@ -9,6 +9,30 @@ import tempfile
 from pathlib import Path
 
 
+class GitError(RuntimeError):
+    """A git command failed with a meaningful error message."""
+
+
+def _run_git(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    secrets: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a git command, raising GitError with redacted stderr on failure."""
+    result = subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True, env=env,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr
+        for secret in secrets or []:
+            if secret:
+                stderr = stderr.replace(secret, "***")
+        raise GitError(f"Command {cmd[0:2]} failed (exit {result.returncode}): {stderr.strip()}")
+    return result
+
+
 def repo_root() -> Path:
     """Return the root of the git repository containing this package."""
     result = subprocess.run(
@@ -117,10 +141,7 @@ def commit_and_push(
         print("No changes to commit.")
         return False
 
-    subprocess.run(
-        ["git", "add", "-A"],
-        cwd=worktree_dir, check=True, capture_output=True,
-    )
+    _run_git(["git", "add", "-A"], cwd=worktree_dir)
 
     env = {
         **os.environ,
@@ -129,15 +150,15 @@ def commit_and_push(
         "GIT_COMMITTER_NAME": bot_name,
         "GIT_COMMITTER_EMAIL": bot_email,
     }
-    subprocess.run(
+    _run_git(
         ["git", "commit", "-m", commit_message],
-        cwd=worktree_dir, check=True, capture_output=True, env=env,
+        cwd=worktree_dir, env=env,
     )
 
     push_url = f"https://x-access-token:{token}@github.com/{owner}/{repo}.git"
-    subprocess.run(
+    _run_git(
         ["git", "push", push_url, f"HEAD:{branch}", "--force"],
-        cwd=worktree_dir, check=True, capture_output=True,
+        cwd=worktree_dir, secrets=[token],
     )
     print(f"Pushed branch {branch}")
     return True


### PR DESCRIPTION
`commit_and_push` was using `subprocess.run(..., check=True, capture_output=True)`. That combo is a trap: `capture_output` eats stderr, and `check=True` raises a `CalledProcessError` that only tells you the exit code. So when a push fails you get:

```
CalledProcessError: returned non-zero exit status 1.
```

Expired token? Branch protection? Permissions? No way to tell.

We hit this in production. A push failed after `pr_draft` completed and the traceback gave us nothing to work with. GitHub App installation tokens expire after an hour, so token expiry during long pipelines is a real failure mode we need to distinguish from other push failures.

### Alternatives considered

**Drop `capture_output` and let stderr print naturally.** Simplest option but two problems. Successful git commands dump noisy progress output to stderr that clutters logs. And the push URL contains the raw GitHub token, so letting stderr flow to the console would leak credentials into CI output.

**Catch `CalledProcessError` at the call site in `resolve.py`.** Doesn't actually help. `CalledProcessError.stderr` is `None` when `capture_output=True` without `text=True`, and even if you fix that you still need token redaction. Every caller would need to know about redaction, which is the wrong place for that concern.

**Use Python `logging` instead of print.** Orthogonal. Worth doing eventually but doesn't solve the invisible stderr problem on its own.

### What we went with

A `_run_git` helper in `git.py` that runs the command, checks the return code, scrubs secrets from stderr, and raises a `GitError` with the actual error message. Callers pass a `secrets` list only when the command contains sensitive values (like the push URL with a token).

The error now looks like:

```
GitError: Command ['git', 'push'] failed (exit 1): remote: Permission to gregology/GaaS.git denied...
```

Only `commit_and_push` uses the helper for now. The other functions (`create_worktree`, `rename_branch`, etc.) still use bare `subprocess.run` since they don't handle secrets and their errors are less ambiguous.
