### PR TITLE
Use _run_git in create_worktree so git failures include the actual error

### DIFF
--- a/gaas-bot/src/gaas_bot/core/git.py
+++ b/gaas-bot/src/gaas_bot/core/git.py
@@ -51,17 +51,14 @@ def create_worktree(branch: str | None = None, *, detach: bool = False) -> Path:
     If detach is True, creates a detached HEAD worktree (for read-only audits).
     """
     root = repo_root()
-    subprocess.run(
-        ["git", "fetch", "origin", "main"],
-        cwd=root, check=True, capture_output=True,
-    )
+    _run_git(["git", "fetch", "origin", "main"], cwd=root)
 
     worktree_dir = Path(tempfile.mkdtemp(prefix="gaas-bot-"))
 
     if detach:
-        subprocess.run(
+        _run_git(
             ["git", "worktree", "add", "--detach", str(worktree_dir), "origin/main"],
-            cwd=root, check=True, capture_output=True,
+            cwd=root,
         )
     elif branch:
         result = subprocess.run(
@@ -69,23 +66,23 @@ def create_worktree(branch: str | None = None, *, detach: bool = False) -> Path:
             cwd=root, capture_output=True,
         )
         if result.returncode == 0:
-            subprocess.run(
+            _run_git(
                 ["git", "branch", "-f", branch, "origin/main"],
-                cwd=root, check=True, capture_output=True,
+                cwd=root,
             )
-            subprocess.run(
+            _run_git(
                 ["git", "worktree", "add", str(worktree_dir), branch],
-                cwd=root, check=True, capture_output=True,
+                cwd=root,
             )
         else:
-            subprocess.run(
+            _run_git(
                 ["git", "worktree", "add", "-b", branch, str(worktree_dir), "origin/main"],
-                cwd=root, check=True, capture_output=True,
+                cwd=root,
             )
     else:
-        subprocess.run(
+        _run_git(
             ["git", "worktree", "add", "--detach", str(worktree_dir), "origin/main"],
-            cwd=root, check=True, capture_output=True,
+            cwd=root,
         )
 
     print(f"Created worktree at {worktree_dir}")


### PR DESCRIPTION
## Summary

`create_worktree` was using bare `subprocess.run(..., check=True, capture_output=True)` for all its git calls. When something goes wrong, `check=True` raises `CalledProcessError` with the exit code but `capture_output=True` swallows stderr. So you get "exit status 128" and zero indication of what actually failed.

Hit this in practice when `git fetch origin main` failed. Could have been a transient network thing, SSH hiccup, whatever. We'll never know because the error message was eaten.

## Alternatives considered

**Dropping `capture_output` entirely** - would print git's stderr to the console during normal operation, which is noisy. Every successful `git fetch` or `git worktree add` would dump progress output. Not great.

**Wrapping each call in try/except to re-raise with stderr** - this is basically reimplementing what `_run_git` already does. The helper was sitting right there in the same file, already handling error capture and redaction. No reason to duplicate that logic.

**Adding `check=False` and manually inspecting returncode** - same problem, just `_run_git` with extra steps.

## Why this approach

The file already had `_run_git` which captures output, checks the return code, redacts secrets from stderr, and raises `GitError` with the actual error message. Six calls in `create_worktree` were ignoring it and using raw `subprocess.run` instead. Switching them over is the obvious fix.

The one `rev-parse --verify` call stays as raw `subprocess.run` on purpose - it uses the return code to check if a branch exists, so raising on failure would be wrong.